### PR TITLE
[KLC-1438] Replace klever.finance with klever.org

### DIFF
--- a/cmd/demo/smartContracts/decode/decode.go
+++ b/cmd/demo/smartContracts/decode/decode.go
@@ -57,7 +57,7 @@ func scReq(endpoint, funcName, scAddress string, args ...string) ([]byte, error)
 
 	req, err := http.NewRequest(
 		"POST",
-		fmt.Sprintf("https://node.testnet.klever.finance/vm/%s", endpoint),
+		fmt.Sprintf("https://node.testnet.klever.org/vm/%s", endpoint),
 		bodyReader,
 	)
 	if err != nil {

--- a/provider/network/networkConfig.go
+++ b/provider/network/networkConfig.go
@@ -37,16 +37,16 @@ func NewNetworkConfig(network Network) NetworkConfig {
 	switch network {
 	case LocalNet:
 	case MainNet:
-		APIUri = "https://api.mainnet.klever.finance"
-		NodeUri = "https://node.mainnet.klever.finance"
+		APIUri = "https://api.mainnet.klever.org"
+		NodeUri = "https://node.mainnet.klever.org"
 		ExplorerUri = "https://kleverscan.org/"
 	case TestNet:
-		APIUri = "https://api.testnet.klever.finance"
-		NodeUri = "https://node.testnet.klever.finance"
+		APIUri = "https://api.testnet.klever.org"
+		NodeUri = "https://node.testnet.klever.org"
 		ExplorerUri = "https://testnet.kleverscan.org/"
 	case DevNet:
-		APIUri = "https://api.devnet.klever.finance"
-		NodeUri = "https://node.devnet.klever.finance"
+		APIUri = "https://api.devnet.klever.org"
+		NodeUri = "https://node.devnet.klever.org"
 		ExplorerUri = "https://klever-explorer-oxw5p5ia3q-uc.a.run.app/"
 	default:
 		panic("invalid network config")


### PR DESCRIPTION
This PR updates all references from the legacy `.finance` domain to the new `.org` domain. The `.finance` domain will be decommissioned at the end of April, making this change necessary to ensure continued functionality