### PR TITLE
[KLC-1885] Add support for multi result encode

### DIFF
--- a/provider/utils/vm.go
+++ b/provider/utils/vm.go
@@ -59,3 +59,14 @@ func IsDynamicLengthType(t string) bool {
 	_, exists := typesMap[t]
 	return exists
 }
+
+// IsVariadicMulti checks if a type is variadic<multi<...>> pattern
+// which requires special handling for multi-result outputs
+func IsVariadicMulti(fullType string) bool {
+	wrapper, inner := SplitTypes(fullType)
+	if wrapper != Variadic {
+		return false
+	}
+	innerWrapper, _ := SplitTypes(inner)
+	return innerWrapper == Multi
+}

--- a/provider/utils/vmConsts.go
+++ b/provider/utils/vmConsts.go
@@ -57,6 +57,7 @@ const (
 	List     string = "List"
 	Option   string = "Option"
 	Tuple    string = "tuple"
+	Multi    string = "multi"
 	Variadic string = "variadic"
 )
 

--- a/provider/vmOutputDecoder.go
+++ b/provider/vmOutputDecoder.go
@@ -16,8 +16,7 @@ import (
 )
 
 type output struct {
-	Type        string `json:"type"`
-	MultiResult bool   `json:"multi_result,omitempty"`
+	Type string `json:"type"`
 }
 
 type endpoint struct {
@@ -113,13 +112,14 @@ func (a *vmOutputData) DecodeHex(endpoint string, hexData []string) (interface{}
 		return nil, err
 	}
 
-	if len(hexData) == 1 {
-		return a.doDecode(&hexData[0], a.Endpoints[*endpointIndex].Outputs[0].Type, 0)
+	// handle variadic<multi<...>> pattern which returns flattened data
+	outputType := a.Endpoints[*endpointIndex].Outputs[0].Type
+	if len(hexData) > 1 && utils.IsVariadicMulti(outputType) {
+		return a.decodeMultiResult(hexData, outputType)
 	}
 
-	// check if the output has multi_result flag
-	if a.Endpoints[*endpointIndex].Outputs[0].MultiResult {
-		return a.decodeMultiResult(hexData, a.Endpoints[*endpointIndex].Outputs[0].Type)
+	if len(hexData) == 1 {
+		return a.doDecode(&hexData[0], a.Endpoints[*endpointIndex].Outputs[0].Type, 0)
 	}
 
 	var decodedValues []interface{}
@@ -144,7 +144,6 @@ func (a *vmOutputData) DecodeHex(endpoint string, hexData []string) (interface{}
 // mainly for multi result outputs
 func (a *vmOutputData) DecodeQuery(endpoint string, base64Data []string) (interface{}, error) {
 	var hexData []string
-
 	for _, data := range base64Data {
 		dataBytes, err := base64.StdEncoding.DecodeString(data)
 		if err != nil {
@@ -156,6 +155,8 @@ func (a *vmOutputData) DecodeQuery(endpoint string, base64Data []string) (interf
 	return a.DecodeHex(endpoint, hexData)
 }
 
+// decodeMultiResult handles the multi_result flag where variadic<multi<A,B,...>>
+// returns data as [a1,b1,a2,b2,...] instead of grouped tuples
 func (a *vmOutputData) decodeMultiResult(hexData []string, fullType string) (interface{}, error) {
 	wrapperType, innerType := utils.SplitTypes(fullType)
 	if wrapperType != utils.Variadic {
@@ -176,17 +177,16 @@ func (a *vmOutputData) decodeMultiResult(hexData []string, fullType string) (int
 
 	var result []interface{}
 
+	// process each group of values
 	for i := 0; i < len(hexData); i += numTypesPerGroup {
 		group := make([]interface{}, numTypesPerGroup)
 
 		for j := 0; j < numTypesPerGroup; j++ {
 			h := hexData[i+j]
-
 			decoded, err := a.doDecode(&h, types[j], 0)
 			if err != nil {
 				return nil, fmt.Errorf("error decoding type %s at index %d: %w", types[j], i+j, err)
 			}
-
 			group[j] = decoded
 		}
 

--- a/provider/vmOutputDecoder.go
+++ b/provider/vmOutputDecoder.go
@@ -16,7 +16,8 @@ import (
 )
 
 type output struct {
-	Type string `json:"type"`
+	Type        string `json:"type"`
+	MultiResult bool   `json:"multi_result,omitempty"`
 }
 
 type endpoint struct {
@@ -116,6 +117,11 @@ func (a *vmOutputData) DecodeHex(endpoint string, hexData []string) (interface{}
 		return a.doDecode(&hexData[0], a.Endpoints[*endpointIndex].Outputs[0].Type, 0)
 	}
 
+	// check if the output has multi_result flag
+	if a.Endpoints[*endpointIndex].Outputs[0].MultiResult {
+		return a.decodeMultiResult(hexData, a.Endpoints[*endpointIndex].Outputs[0].Type)
+	}
+
 	var decodedValues []interface{}
 
 	var outputIndex int
@@ -148,6 +154,46 @@ func (a *vmOutputData) DecodeQuery(endpoint string, base64Data []string) (interf
 	}
 
 	return a.DecodeHex(endpoint, hexData)
+}
+
+func (a *vmOutputData) decodeMultiResult(hexData []string, fullType string) (interface{}, error) {
+	wrapperType, innerType := utils.SplitTypes(fullType)
+	if wrapperType != utils.Variadic {
+		return nil, fmt.Errorf("multi_result expects variadic type, got %s", wrapperType)
+	}
+
+	multiWrapper, tupleTypes := utils.SplitTypes(innerType)
+	if multiWrapper != utils.Multi {
+		return nil, fmt.Errorf("multi_result expects multi type inside variadic, got %s", multiWrapper)
+	}
+
+	types := utils.SplitTupleTypes(tupleTypes)
+	numTypesPerGroup := len(types)
+
+	if len(hexData)%numTypesPerGroup != 0 {
+		return nil, fmt.Errorf("hex data length %d is not a multiple of types count %d", len(hexData), numTypesPerGroup)
+	}
+
+	var result []interface{}
+
+	for i := 0; i < len(hexData); i += numTypesPerGroup {
+		group := make([]interface{}, numTypesPerGroup)
+
+		for j := 0; j < numTypesPerGroup; j++ {
+			h := hexData[i+j]
+
+			decoded, err := a.doDecode(&h, types[j], 0)
+			if err != nil {
+				return nil, fmt.Errorf("error decoding type %s at index %d: %w", types[j], i+j, err)
+			}
+
+			group[j] = decoded
+		}
+
+		result = append(result, group)
+	}
+
+	return result, nil
 }
 
 func (a *vmOutputData) findEndpoint(endpointName string) (*int, error) {

--- a/provider/vmOutputDecoder.go
+++ b/provider/vmOutputDecoder.go
@@ -175,11 +175,15 @@ func (a *vmOutputData) decodeMultiResult(hexData []string, fullType string) (int
 	types := utils.SplitTupleTypes(tupleTypes)
 	numTypesPerGroup := len(types)
 
+	if numTypesPerGroup == 0 {
+		return nil, fmt.Errorf("multi_result has no inner types for %s", fullType)
+	}
+
 	if len(hexData)%numTypesPerGroup != 0 {
 		return nil, fmt.Errorf("hex data length %d is not a multiple of types count %d", len(hexData), numTypesPerGroup)
 	}
 
-	var result []interface{}
+	result := make([]interface{}, 0, len(hexData)/numTypesPerGroup)
 
 	// process each group of values
 	for i := 0; i < len(hexData); i += numTypesPerGroup {

--- a/provider/vmOutputDecoder.go
+++ b/provider/vmOutputDecoder.go
@@ -112,6 +112,10 @@ func (a *vmOutputData) DecodeHex(endpoint string, hexData []string) (interface{}
 		return nil, err
 	}
 
+	if len(a.Endpoints[*endpointIndex].Outputs) == 0 {
+		return nil, fmt.Errorf("endpoint %s has no outputs defined", endpoint)
+	}
+
 	// handle variadic<multi<...>> pattern which returns flattened data
 	outputType := a.Endpoints[*endpointIndex].Outputs[0].Type
 	if len(hexData) > 1 && utils.IsVariadicMulti(outputType) {


### PR DESCRIPTION
This pull request introduces support for decoding outputs with the `variadic<multi<...>>` type pattern in the VM output decoder. This pattern is used for multi-result outputs that require special handling, ensuring that flattened output data is correctly grouped and decoded. The changes include the addition of new type constants, utility functions for type parsing, and a dedicated decoding method.

**Support for variadic multi-result output decoding:**

* Added the `Multi` type constant to `vmConsts.go` to represent multi-result output types.
* Implemented the `IsVariadicMulti` utility function in `vm.go` to detect the `variadic<multi<...>>` type pattern for outputs requiring special handling.

**VM output decoder enhancements:**

* Updated the `DecodeHex` method in `vmOutputDecoder.go` to detect and handle the `variadic<multi<...>>` output pattern, delegating decoding to a new specialized method when necessary.
* Added the `decodeMultiResult` method to `vmOutputDecoder.go` to group and decode flattened output data for `variadic<multi<...>>` types, ensuring correct mapping of values to their respective types.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Suporte à decodificação de saídas variádicas com múltiplos componentes, permitindo processar conjuntos de tipos agrupados e aninhados.
  * Detecção automática desses padrões variádicos para roteamento adequado do processo de decodificação.

* **Melhorias**
  * Mensagens de erro mais contextuais ao falhar na decodificação de grupos, facilitando diagnóstico.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->